### PR TITLE
Unsubscribe plugin now using Subscriber Model

### DIFF
--- a/migrations/2015_02_15_202624_update_subscriptions_add_uuid.php
+++ b/migrations/2015_02_15_202624_update_subscriptions_add_uuid.php
@@ -1,0 +1,32 @@
+<?php
+
+//use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class UpdateSubscriptionsAddUuid extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('subscribers', function($table) {
+            $table->string('uuid')->unique();
+        });
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+        Schema::table('subscribers', function($table) {
+            $table->dropColumn('uuid');
+        });
+	}
+
+}

--- a/migrations/2015_02_15_203127_update_subscriptions_nullify_verification.php
+++ b/migrations/2015_02_15_203127_update_subscriptions_nullify_verification.php
@@ -1,0 +1,27 @@
+<?php
+
+use October\Rain\Database\Updates\Migration;
+
+class UpdateSubscriptionsNullifyVerification extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		DB::statement('ALTER TABLE `subscribers` MODIFY `verificationDate` datetime NULL;');
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+        DB::statement('ALTER TABLE `subscribers` MODIFY `verificationDate` datetime NOT NULL;');
+	}
+
+}

--- a/plugins/lasso/unsubscribe/Plugin.php
+++ b/plugins/lasso/unsubscribe/Plugin.php
@@ -7,6 +7,7 @@ use System\Classes\PluginBase;
  */
 class Plugin extends PluginBase
 {
+    public $require = ['Lasso.Subscribe'];
 
     /**
      * Returns information about this plugin.

--- a/plugins/lasso/unsubscribe/components/UnsubscribeHandler.php
+++ b/plugins/lasso/unsubscribe/components/UnsubscribeHandler.php
@@ -1,6 +1,7 @@
 <?php namespace Lasso\Unsubscribe\Components;
 
 use Cms\Classes\ComponentBase;
+use Lasso\Subscribe\Models\Subscribe;
 
 class UnsubscribeHandler extends ComponentBase
 {
@@ -32,17 +33,17 @@ class UnsubscribeHandler extends ComponentBase
             return;
         }
 
-        //$user = Subscriber::whereRaw('email = ? and uuid = ?', array($email, $uuid))->take(1)->get();
-        $user = true;
+        $user = Subscribe::whereRaw('email = ? and uuid = ?', array($email, $uuid));
+        //$user = true;
 
-        if (!$user) {
+        if ($user->count() == 0) {
             // Throw some error page
             $this->success = false;
             $this->message = "Email Not Found";
             return;
         }
 
-        //$user->delete();
+        $user->delete();
 
         $this->success = true;
         $this->message = "You have been successfully unsubscribed from the mailing list.";


### PR DESCRIPTION
Unsubscribe plugin is now working.
Had to add some migrations to make the subscriber model work (Subscribe form now works as a result).
Format for unsubscribe link is: /unsubscribe/{email}/{uuid}
