### PR TITLE
Verification Email + Account Verification

### DIFF
--- a/plugins/lasso/subscribe/Plugin.php
+++ b/plugins/lasso/subscribe/Plugin.php
@@ -2,7 +2,7 @@
     namespace Lasso\Subscribe;
 
     use System\Classes\PluginBase;
-
+    use Illuminate\Support\Facades\DB;
     class Plugin extends PluginBase
     {
         public function pluginDetails()
@@ -20,5 +20,27 @@
             return [
                 '\lasso\Subscribe\Components\Form' => 'SubForm'
             ];
+        }
+
+        public function registerMailTemplates(){
+            return [
+                'lasso.subscribe::mail.verify' => 'Verification email sent to new subscribers.',
+            ];
+        }
+
+        public function registerSchedule($schedule)
+        {
+            // Check if old unverified entries need to be deleted
+            $schedule->call(function(){
+                $results = Db::select('select * from subscribers where verificationDate IS NULL');
+                $now = date('Y-m-d H:i:s');
+                $timeLimit = 3 * 60;
+                foreach($results as $val){
+                    $checkIn = $val->created_at;
+                    if(strtotime($now) - strtotime($checkIn) > $timeLimit){
+                        Db::delete('delete from subscribers where uuid = "'.$val->uuid.'"');
+                    }
+                }
+            })->everyFiveMinutes();
         }
     }

--- a/plugins/lasso/subscribe/Routes.php
+++ b/plugins/lasso/subscribe/Routes.php
@@ -1,0 +1,4 @@
+<?php
+    use Lasso\Subscribe\Controllers\VerifyController;
+
+    Route::get('subscribe/verify/{uuid}', 'Lasso\Subscribe\Controllers\VerifyController@commit');

--- a/plugins/lasso/subscribe/components/Form.php
+++ b/plugins/lasso/subscribe/components/Form.php
@@ -2,6 +2,7 @@
 namespace Lasso\Subscribe\Components;
 
 use Cms\Classes\ComponentBase;
+use Mail;
 
 class Form extends ComponentBase{
     public function componentDetails(){
@@ -35,12 +36,16 @@ class Form extends ComponentBase{
         }
         else{
             $subscription = new \lasso\subscribe\models\Subscribe;
-            $subscription->uuid = $subscription->generateUUID();
+            $subscription->uuid = $uuid = $subscription->generateUUID();
             $subscription->name = $name;
             $subscription->email = $email;
             $subscription->zip = $zip;
             $subscription->type = $subscription->type2int($type);
             $subscription->save();
+            $params = ['name' => $name, 'email' => $email, 'uuid' => $uuid];
+
+
+            Mail::sendTo([$email => $name], 'lasso.subscribe::mail.verify', $params);
         }
 
 

--- a/plugins/lasso/subscribe/controllers/VerifyController.php
+++ b/plugins/lasso/subscribe/controllers/VerifyController.php
@@ -1,0 +1,18 @@
+<?php
+    namespace Lasso\Subscribe\Controllers;
+
+    class VerifyController extends \System\Classes\Controller{
+        public function commit($uuid){
+            $subscription = new \lasso\subscribe\models\Subscribe;
+            if($subscription->UUID($uuid)->count() == 1){
+                $verifier = \lasso\subscribe\models\Subscribe::find($uuid);
+                $verifier->verificationDate = date('Y-m-d H:i:s');
+                $verifier->save();
+                return "Account Verified";
+            }
+            else{
+                return "Invalid Authentication Token";
+            }
+
+        }
+    }

--- a/plugins/lasso/subscribe/models/Subscribe.php
+++ b/plugins/lasso/subscribe/models/Subscribe.php
@@ -6,18 +6,18 @@
     class Subscribe extends Model
     {
         protected $table = 'subscribers';
-        public $timestamps = false;
+        protected $primaryKey = 'uuid';
 
         protected $fillable = [
             'name',
             'email',
             'zip',
-            'type'
+            'type',
+            'verificationDate'
         ];
 
         protected $guarded = [
-            'uuid',
-            'verificationDate'
+            'uuid'
         ];
 
         public function scopeEmail($query, $email){
@@ -34,6 +34,14 @@
 
         public function scopeType($query, $type){
             return $query->where('type', '=', $type);
+        }
+
+        public function  scopeUUID($query, $uuid){
+            return $query->where('uuid', '=', $uuid);
+        }
+
+        public function scopeNotVerified($query){
+            return $query->where('verificationDate', 'IS', 'NULL');
         }
 
         public function generateUUID(){

--- a/plugins/lasso/subscribe/views/mail/verify.htm
+++ b/plugins/lasso/subscribe/views/mail/verify.htm
@@ -1,0 +1,12 @@
+subject = "Eastern Adocacy Mailing List"
+==
+
+<p>Hello {{ name }},</p>
+
+<p>You are receiving this email because you recently subscribed to the Eastern Advocacy mailing list.</p>
+
+<p>Account verification is required within 24 hours, please click on the link below.</p>
+
+<a href="{{ '/subscribe/verify/{{uuid}}'|app }}"><h1>Verify my subscription.</h1></a>
+
+<p>If you did not subscribe you can safely ignore this email as our systems will automatically remove your email address.</p>


### PR DESCRIPTION
Added subscription verification:
- Verification email
- New routes to handle verification attempts
- New controller to perform verification of accounts
- Scheduled task to remove old unverified entries
- Currently set to 3 minutes for testing
- uses cron job so might only work on linux
