### PR TITLE
Petition Bug fixes

### DIFF
--- a/plugins/lasso/adminsendmail/routes.php
+++ b/plugins/lasso/adminsendmail/routes.php
@@ -1,0 +1,8 @@
+<?php
+
+Route::get('sendmail/new', function()
+{
+	return 'Sending a new email';
+});
+
+Route::post('sendmail/new', array('uses' => 'SendMailController@preview'));

--- a/plugins/lasso/petitions/Plugin.php
+++ b/plugins/lasso/petitions/Plugin.php
@@ -29,15 +29,7 @@
             return [
 			'Lasso\Petitions\Components\Viewpost' => 'viewPost',
                 'Lasso\Petitions\Components\Frontend' => 'frontEnd',
-            ];
-        }
-
-        public function registerReportWidgets() {
-            return [
-                '\Lasso\Petitions\ReportWidgets\TopPetitions' => [
-                    'label' => 'Top Petitions',
-                    'context' => 'dashboard',
-                ],
+                'Lasso\Petitions\Components\HomePage' => 'homePage',
             ];
         }
 

--- a/plugins/lasso/petitions/assets/css/style.css
+++ b/plugins/lasso/petitions/assets/css/style.css
@@ -1,3 +1,8 @@
+.alert-error {
+    background-color: #cc3300;
+    border-color: #d6e9c6;
+    color: #000012;
+}
 .form{
     float: left;
     margin: 4px;

--- a/plugins/lasso/petitions/components/Frontend.php
+++ b/plugins/lasso/petitions/components/Frontend.php
@@ -29,6 +29,12 @@ class Frontend extends \Cms\Classes\ComponentBase
     public function defineProperties()
     {
         return [
+            'showPublished' =>[
+                'title' => 'Show Published',
+                'description' => 'Show only published petitions',
+                'type' => 'checkbox',
+                'default' => 'true',
+            ],
             'pageNumber' => [
                 'title'       => 'Page Number',
                 'description' => 'Determines the page that the user is on',
@@ -40,7 +46,7 @@ class Frontend extends \Cms\Classes\ComponentBase
                 'description'       => 'Number of petitions to display per page.',
                 'type'              => 'string',
                 'validationPattern' => '^[0-9]+$',
-                'validationMessage' => 'Invalid format of the posts per page value',
+                'validationMessage' => 'Invalid format of the petitions per page value',
                 'default'           => '10',
             ],
             'noPetitionsMessage' => [
@@ -59,31 +65,18 @@ class Frontend extends \Cms\Classes\ComponentBase
         ];
     }
 
-/*    function petitions()
-    {
-        $petitions = \Lasso\Petitions\Models\Petitions::Active()->get();
-        $result = [];
-        foreach($petitions as $petition){
-            $store = [];
-            foreach($petition as $code => $data){
-                $store[$code] = $data;
-            }
-            $result[$petition['title']] = $store;
-        }
-        return $result;
-    }*/
-
     public function getPetitionPageOptions()
     {
         return Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName');
     }
     public function onRun()
     {
+        $this->addJs('/plugins/lasso/petitions/assets/ajax.js');
         $this->prepareVars();
 
-        $this->petitions = $this->page['petitions'] = \Lasso\Petitions\Models\Petitions::orderBy('created_at', 'desc')->listPosts([
+        $this->petitions = $this->page['petitions'] = \Lasso\Petitions\Models\Petitions::Published()->orderBy('created_at', 'desc')->listPosts([
             'page'          => $this->property('pageNumber'),
-            'petitionsPerPage'  => $this->property('petitionsPerPage')
+            'petitionsPerPage'  => $this->property('petitionsPerPage'),
         ]);
 
         $this->petitions->each(function($petition) {
@@ -105,10 +98,5 @@ class Frontend extends \Cms\Classes\ComponentBase
         $this->pageParam = $this->page['pageParam'] = $this->paramName('pageNumber');
         $this->noPostsMessage = $this->page['noPetitionsMessage'] = $this->property('noPetitionsMessage');
         $this->postPage = $this->page['petitionPage'] = $this->property('petitionPage');
-        $pn = $this->property('pageNumber');
-        /*$this->noPetitionsMessage = $this->page['noPetitionsMessage'] = $this->property('noPetitionsMessage');
-        $this->petitionPage = $this->page['petitionPage'] = $this->property('petitionPage');
-        $this->pageNumber = $this->page['pageNumber']  = $this->paramName('pageNumber', $pn);
-        $this->petitionsPerPage = $this->page['petitionsPerPage'] = $this->property('petitionsPerPage');*/
     }
 }

--- a/plugins/lasso/petitions/components/HomePage.php
+++ b/plugins/lasso/petitions/components/HomePage.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Wolf
+ * Date: 4/23/2015
+ * Time: 1:57 PM
+ */
+namespace Lasso\Petitions\Components;
+use Illuminate\Support\Facades\DB;
+use Lasso\Petitions\Controllers\Petitions;
+use Redirect;
+use Cms\Classes\Page;
+
+class HomePage extends \Cms\Classes\ComponentBase
+{
+    public $petitions;
+
+    function componentDetails()
+    {
+        return [
+            'name' => 'Petition Homepage List View',
+            'description' => 'Homepage list view for petitions',
+        ];
+    }
+
+    public function defineProperties()
+    {
+        return [
+            'petitionsOnHomePage' => [
+                'title'             => 'Petitions On Home Page',
+                'description'       => 'Number of petitions to display on home page.',
+                'type'              => 'string',
+                'validationPattern' => '^[0-9]+$',
+                'validationMessage' => 'Invalid format',
+                'default'           => '5',
+            ],
+            'noPetitionsMessage' => [
+                'title'        => 'No Petitions Message',
+                'description'  => 'Message to be displayed if no petitions are found',
+                'type'         => 'string',
+                'default'      => 'No petitions found'
+            ],
+        ];
+    }
+
+        function petitions()
+        {
+            $petitions = \Lasso\Petitions\Models\Petitions::Published()->orderBy('created_at', 'desc')->take($this->property('petitionsOnHomePage'))->get();
+            $result = [];
+            foreach($petitions as $petition){
+                $store = [];
+                foreach($petition as $code => $data){
+                    $store[$code] = $data;
+                }
+                $result[$petition['title']] = $store;
+            }
+            return $result;
+        }
+
+    public function onRun()
+    {
+        $this->addJs('/plugins/lasso/petitions/assets/ajax.js');
+        $this->prepareVars();
+    }
+
+    protected function prepareVars()
+    {
+        $this->noPostsMessage = $this->page['noPetitionsMessage'] = $this->property('noPetitionsMessage');
+        $this->postPage = $this->page['petitionPage'] = $this->property('petitionPage');
+        $this->petitions = $this->petitions();
+
+    }
+}

--- a/plugins/lasso/petitions/components/frontend/default.htm
+++ b/plugins/lasso/petitions/components/frontend/default.htm
@@ -1,15 +1,15 @@
 
 <div class="row">
-    <article id="lasso-petitions" class="col-md-6 col-md-offset-3">
+    <article id="lasso-petitions" class="advocacy-article col-md-6 col-md-offset-3">
         <header><h2>Petitions</h2></header>
 
         <ul class="media-list">
         {% for petition in frontEnd.petitions %}
             <li class="media">
                 <div class="media-body">
-                    <h4 class="media-heading post-subject" ><a class="petition-title" href="{{ ['petition'|page, '/', petition.attributes.slug]|join  }}">{{ petition.attributes.title }}</a></h4>
+                    <h4 class="media-heading post-subject" ><a class="petition-title" href="{{ ['p'|app, '/', petition.attributes.slug]|join  }}">{{ petition.attributes.title }}</a></h4>
                     <p class="petition-summary">{{petition.attributes.summary}}</p>
-                    <a href="{{ ['petition'|page, '/', petition.attributes.slug]|join }}">Read More...</a>
+                    <a href="{{ ['p'|page, '/', petition.attributes.slug]|join }}">Read More...</a>
                     <p class="petition-date text-right">{{ petition.attributes.created_at|date("m/d/Y") }} - {{ petition.attributes.created_at|date("h:i") }}</p>
                 </div>
             </li>
@@ -18,10 +18,10 @@
         </ul>
         {% if petitions.lastPage > 1 %}
         <ul class="pagination">
+            <input id="currentPage" type="hidden" value="{{ petitions.currentPage }}"/>
             {% if petitions.currentPage > 1 %}
-            <li><a href="{{ this.page.baseFileName|page({ (pageParam): (petitions.currentPage-1) }) }}">&larr; Prev</a></li>
+            <li><a class="prev" href="{{ this.page.baseFileName|page({ (pageParam): (petitions.currentPage-1) }) }}">&larr; Prev</a></li>
             {% endif %}
-
             {% for page in 1..petitions.lastPage %}
             <li class="{{ petitions.currentPage == page ? 'active' : null }}">
                 <a href="{{ this.page.baseFileName|page({ (pageParam): page }) }}">{{ page }}</a>
@@ -29,7 +29,7 @@
             {% endfor %}
 
             {% if petitions.lastPage > petitions.currentPage %}
-            <li><a href="{{ this.page.baseFileName|page({ (pageParam): (petitions.currentPage+1) }) }}">Next &rarr;</a></li>
+            <li><a class="next" href="{{ this.page.baseFileName|page({ (pageParam): (petitions.currentPage+1) }) }}">Next &rarr;</a></li>
             {% endif %}
         </ul>
         {% endif %}

--- a/plugins/lasso/petitions/components/homePage/default.htm
+++ b/plugins/lasso/petitions/components/homePage/default.htm
@@ -1,0 +1,19 @@
+<div class="row">
+    <article id="lasso-petitions" class="advocacy-article col-md-6 col-md-offset-3">
+        <header><h2>Petitions</h2></header>
+
+        <ul class="media-list">
+            {% for petition in homePage.petitions %}
+            <li class="media">
+                <div class="media-body">
+                    <h4 class="media-heading post-subject" ><a class="petition-title" href="{{ ['p'|app, '/', petition.attributes.slug]|join  }}">{{ petition.attributes.title }}</a></h4>
+                    <p class="petition-summary">{{petition.attributes.summary}}</p>
+                    <a href="{{ ['p'|app, '/', petition.attributes.slug]|join }}">Read More...</a>
+                    <p class="petition-date text-right">{{ petition.attributes.created_at|date("m/d/Y") }} - {{ petition.attributes.created_at|date("h:i") }}</p>
+                </div>
+            </li>
+            <li class="divider"></li>
+            {% endfor %}
+        </ul>
+    </article>
+</div>

--- a/plugins/lasso/petitions/components/viewpost/default.htm
+++ b/plugins/lasso/petitions/components/viewpost/default.htm
@@ -4,34 +4,65 @@
 <div class="petition">
     {% if petitionInfo is empty %}
         <h1>Invalid Petition</h1>
+    {% elseif petitionInfo.published == false %}
+        <h1>Access Restricted. Petition is not currently published</h1>
     {% else %}
     <div class="form">
-        {{ form_open({ request: 'signPetition' }) }}
-        <ul class="form-items">
-            <li>
-                <h2>Count Me In: </h2>
-            </li>
-            <li>
-                <input id="name" type="text" value="" name="name" placeholder="Name" required/>
-            </li>
-            <li>
-                <input id="email" type="email" value="" name="email" placeholder="name@example.com" required pattern="^([\w\.\-_]+)?\w+@[\w-_]+(\.\w+){1,}$"/>
-            </li>
-            <li>
-                <input name="mailingaddress" type="text" id="mailingaddress" placeholder="Address" required/>
-            </li>
-            <li>
-                <input type="text" name="city" id="city" placeholder="City" required/>
-            </li>
-            <li>
-                <input id="zip" type="text" value="" name="zip" placeholder="Enter zip code" required pattern="^\d{5}(\-?\d{4})?$"/>
-            </li>
-            <li>
-                <button type="submit" class="submit">Sign</button>
-            </li>
-            <input type="hidden" name="pid" value="{{ petitionInfo.pid }}"/>
-        </ul>
-        {{ form_close() }}
+        {% if petitionInfo.active == true %}
+            {{ form_open({ request: 'signPetition' }) }}
+            <ul class="form-items">
+                <li>
+                    <h2>Count Me In: </h2>
+                </li>
+                <li>
+                    <input id="name" type="text" value="" name="name" placeholder="Name" required/>
+                </li>
+                <li>
+                    <input id="email" type="email" value="" name="email" placeholder="name@example.com" required pattern="^([\w\.\-_]+)?\w+@[\w-_]+(\.\w+){1,}$"/>
+                </li>
+                <li>
+                    <input name="mailingaddress" type="text" id="mailingaddress" placeholder="Address" required/>
+                </li>
+                <li>
+                    <input type="text" name="city" id="city" placeholder="City" required/>
+                </li>
+                <li>
+                    <input id="zip" type="text" value="" name="zip" placeholder="Enter zip code" required pattern="^\d{5}(\-?\d{4})?$"/>
+                </li>
+                <li>
+                    <button type="submit" class="submit">Sign</button>
+                </li>
+                <input type="hidden" name="pid" value="{{ petitionInfo.pid }}"/>
+            </ul>
+            {{ form_close() }}
+        {% elseif petitionInfo.active == false %}
+            {{ form_open({ request: 'signPetition' }) }}
+            <ul class="form-items">
+                <li>
+                    <h2>Count Me In: </h2>
+                </li>
+                <li>
+                    <input id="name" type="text" value="" name="name" placeholder="Name" required disabled/>
+                </li>
+                <li>
+                    <input disabled id="email" type="email" value="" name="email" placeholder="name@example.com" required pattern="^([\w\.\-_]+)?\w+@[\w-_]+(\.\w+){1,}$"/>
+                </li>
+                <li>
+                    <input disabled name="mailingaddress" type="text" id="mailingaddress" placeholder="Address" required/>
+                </li>
+                <li>
+                    <input disabled type="text" name="city" id="city" placeholder="City" required/>
+                </li>
+                <li>
+                    <input disabled id="zip" type="text" value="" name="zip" placeholder="Enter zip code" required pattern="^\d{5}(\-?\d{4})?$"/>
+                </li>
+                <li>
+                    <button disabled type="submit" class="submit">Sign</button>
+                </li>
+                <input type="hidden" name="pid" value="{{ petitionInfo.pid }}"/>
+            </ul>
+            {{ form_close() }}
+        {% endif %}
     </div>
     <div class="info">
         {{ petitionInfo.attributes.title }}
@@ -39,6 +70,5 @@
         <h2>Cause</h2>
         {{ petitionInfo.attributes.body|raw}}
     </div>
-    {% partial "share_dialog::default" title = petitionInfo.attributes.title description = petitionInfo.attributes.summary %}
     {% endif %}
 </div>

--- a/plugins/lasso/petitions/models/Signatures.php
+++ b/plugins/lasso/petitions/models/Signatures.php
@@ -9,6 +9,7 @@
 namespace Lasso\Petitions\Models;
 
 use Model;
+use Mail;
 
 class Signatures extends Model
 {
@@ -50,5 +51,16 @@ class Signatures extends Model
             return 0;
         }
         return 1;
+    }
+
+    public function scopeEmailSignatures($query, $pid)
+    {
+        $results = \Lasso\Petitions\Models\Signatures::Pid($pid)->get();
+        $petition = \Lasso\Petitions\Models\Petitions::Pid($pid)->first();
+
+        foreach ($results as $r) {
+            $params = ['name' => $r->name, 'email' => $r->email, 'petitionName' => $petition->title, 'slug' => $petition->slug];
+            Mail::sendTo([$r->email => $r->name], 'lasso.petitions::mail.petition_changed', $params);
+        }
     }
 }

--- a/plugins/lasso/petitions/models/petitions/fields.yaml
+++ b/plugins/lasso/petitions/models/petitions/fields.yaml
@@ -19,12 +19,12 @@ fields:
         required: true
     published:
         label: Published?
-        description: Publish petition right away?
+        description: Publish petition so that it can be viewed on the frontend.
         type: checkbox
         default: true
     active:
-        label: Petition is currently active?
-        description: Petition is active if goal has not been met
+        label: Active?
+        description: Petition is active and able to be signed.
         type: checkbox
         default: true
     goal:

--- a/plugins/lasso/petitions/updates/SeedPetitionsTable.php
+++ b/plugins/lasso/petitions/updates/SeedPetitionsTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lasso\Petitions\Updates;
+
+use Seeder;
+use Lasso\Petitions\Models\Petitions;
+use Faker;
+
+class SeedPetitionsTable extends Seeder{
+    public function run(){
+        $faker = Faker\Factory::Create();
+
+        for($i = 0; $i < 100; $i++){
+            $petition = Petitions::create(
+                array(
+                    'title' => $faker->sentence(5),
+                    'summary' => $faker->text(50),
+                    'body' => $faker->text(250),
+                    'goal' => $faker->randomNumber(3),
+                )
+            );
+        }
+    }
+}

--- a/plugins/lasso/petitions/updates/version.yaml
+++ b/plugins/lasso/petitions/updates/version.yaml
@@ -41,8 +41,17 @@
     - Added backend list toolbar add and delete
 1.5.3:
     - Added db seeding using faker
-    - seed_petitions_table.php
+    - SeedPetitionsTable.php
 1.5.4:
     - Added Pagination to frontend component
     - Refactored components, removed post component, renamed frontend to petition list view
+1.5.5:
+    - Fixed bug causing trivial changes, such as published or active, to trigger the immutability functions
+    - Added published functionality to petitions front end only published petitions will be viewable
+    - Added active functionality to petitions front end unactive petitions are still viewable but cannot be signed
+    - Added homePage component to home page in theme
+    - Added frontend component to Sign Petition page in theme
+    - Changed components class tags to match the theme and have the correct width.
+    - Fixed bug that was causing petitions signature count not to be reset when the immutability functions where triggered.
+    - Fixed css bug where alerts with type error had no styling, there was no css rule for .alert-error in the theme style.css, I added a rule to htis components css.
     

--- a/plugins/lasso/ziplookup/Plugin.php
+++ b/plugins/lasso/ziplookup/Plugin.php
@@ -1,0 +1,35 @@
+<?php namespace Lasso\ZipLookup;
+
+use System\Classes\PluginBase;
+
+/**
+ * ZipLookup Plugin Information File
+ */
+class Plugin extends PluginBase
+{
+
+    /**
+     * Returns information about this plugin.
+     *
+     * @return array
+     */
+    public function pluginDetails()
+    {
+        return [
+            'name'        => 'ZipLookup',
+            'description' => 'Method to lookup legislator by zip code',
+            'author'      => 'Team Lasso - Dan Aldous',
+            'icon'        => 'icon-leaf'
+        ];
+    }
+
+    /**
+     * @return array
+     */
+	public function registerComponents()
+	{
+		return [
+			'\Lasso\ZipLookup\Components\Zip' => 'zip'
+		];
+	}
+}

--- a/plugins/lasso/ziplookup/components/Zip.php
+++ b/plugins/lasso/ziplookup/components/Zip.php
@@ -1,0 +1,92 @@
+<?php namespace Lasso\ZipLookup\Components;
+
+use Cms\Classes\ComponentBase;
+use Lasso\ZipLookup\Models\ZipRecord;
+use Lasso\ZipLookup\Models\Rep;
+
+class Zip extends ComponentBase {
+    /**
+     * zipcode, read as string
+     * @var string
+     */
+    public $zipCode;
+    /**
+     * array of representatives
+     * @var array
+     */
+    public $representatives;
+
+    public function componentDetails() {
+        return [
+            'name'        => 'Zip',
+            'description' => 'Zip Lookup Plugin'
+        ];
+    }
+    public function defineProperties() {
+	    return [
+            'userID' => [
+            'title'         => 'User ID',
+            'description'   => 'User ID to access legislator API',
+            'default'       => 'edf3725acca94c9a897416cd3517f08e',
+            'type'          => 'string'
+            ],
+            'visibleOutput' => [
+            'title'         => 'Visible Output',
+            'description'   => 'Output results visibly, as opposed to returning JSON data',
+            'default'       => 'visible',
+            'type'          => 'dropdown',
+            'options'       => ['visible'=>'Visible', 'json'=>'JSON']
+            ]
+	    ];
+    }
+    public function onSearchZip() {
+        $zipCode = post('zipCode');
+        $zipRecord = ZipRecord::where('zip', '=', intval($zipCode))->first();
+
+        if (!$zipRecord) {
+            $representatives = Zip::info($zipCode);
+            foreach($representatives as $rep) {
+                $repRecord = (Rep::whereraw('firstName = ? AND lastName = ? ',
+                    array($rep->first_name, $rep->last_name))->first());
+                if (!$repRecord) {
+                    $repRecord = Rep::create(['firstName' => $rep->first_name,
+                        'lastName' => $rep->last_name,
+                        'title' => $rep->title,
+                        'politicalParty' => $rep->party,
+                        'emailAddress' => $rep->oc_email,
+                        'phoneNumber' => $rep->phone,
+                        'physicalAddress' => $rep->office . ", " . $rep->state,
+                        'expireDate' => $rep->term_end]);
+                    $repRecord->save();
+                }
+                $zipRecord = new ZipRecord();
+                $zipRecord->zip = $zipCode;
+                $zipRecord->representative_id = $repRecord->id;
+                $zipRecord->save();
+            }
+        }
+        unset($representatives);
+        $representatives = array();
+        if($zipRecord) {
+            $repsIds = ZipRecord::where('zip', '=', $zipRecord->zip);
+            foreach ($repsIds->get() as $zipIndex) {
+                $repIndex = $zipIndex->representative_id;
+                $rep = Rep::where('id', '=', $repIndex)->first();
+                array_push($representatives, $rep);
+            }
+        }
+        if($this->properties['visibleOutput']=='visible') {
+            $this->representatives = $representatives;
+        } else {
+            return $representatives;
+        }
+    }
+    public function info($zipCode) {
+        $json = file_get_contents(sprintf(
+            "https://congress.api.sunlightfoundation.com/legislators/locate?zip=%s&apikey=%s",
+            $zipCode,
+            $this->property('userID')
+        ));
+        return json_decode($json)->{'results'};
+    }
+}

--- a/plugins/lasso/ziplookup/components/zip/default.htm
+++ b/plugins/lasso/ziplookup/components/zip/default.htm
@@ -1,0 +1,19 @@
+<form
+        data-request="{{__SELF__}}::onSearchZip"
+        data-request-success="$('#zipCode').val('')"
+        data-request-update="'{{__SELF__}}::results': '#go'"
+        >
+    <div class="panel panel-default">
+        <div class="panel-body">
+            <div class="input-group">
+                <input name="zipCode" type="text" id="zipCode" class="form-control" value=""/>
+                <span class="input-group-btn">
+                    <button type="submit" class="btn btn-primary">Search</button>
+                </span>
+            </div>
+            <ul class="list-group" id="go">
+                {% partial '@results' %}
+            </ul>
+        </div>
+    </div>
+</form>

--- a/plugins/lasso/ziplookup/components/zip/results.htm
+++ b/plugins/lasso/ziplookup/components/zip/results.htm
@@ -1,0 +1,13 @@
+{%set reps = __SELF__.representatives%}
+
+{% for rep in reps %}
+    <li>
+        <p>{{rep.title}} {{rep.firstName}} {{rep.lastName}} ({{rep.politicalParty}})
+            <br /><a href="mailto:{{rep.emailAddress}}">{{rep.emailAddress}}</a>
+            <br />{{rep.physicalAddress}}
+            <br />{{rep.phoneNumber}}
+        </p>
+    </li>
+{% else %}
+    <li>No results found</li>
+{% endfor %}

--- a/plugins/lasso/ziplookup/controllers/ZipLookup.php
+++ b/plugins/lasso/ziplookup/controllers/ZipLookup.php
@@ -1,0 +1,25 @@
+<?php namespace \Lasso\ZipLookup\Controllers;
+
+use BackendMenu;
+use Backend\Classes\Controller;
+
+/**
+ * ZipLookup Back-end Controller
+ */
+class ZipLookup extends Controller
+{
+    public $implement = [
+        'Backend.Behaviors.FormController',
+        'Backend.Behaviors.ListController'
+    ];
+
+    public $formConfig = 'config_form.yaml';
+    public $listConfig = 'config_list.yaml';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        BackendMenu::setContext('.Lasso\ZipLookup', 'lasso\ziplookup', 'ziplookup');
+    }
+}

--- a/plugins/lasso/ziplookup/controllers/ziplookup/_list_toolbar.htm
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/_list_toolbar.htm
@@ -1,0 +1,3 @@
+<div data-control="toolbar">
+    <a href="<?= Backend::url('/lasso/ziplookup/ziplookup/create') ?>" class="btn btn-primary oc-icon-plus">New ZipLookup</a>
+</div>

--- a/plugins/lasso/ziplookup/controllers/ziplookup/config_form.yaml
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/config_form.yaml
@@ -1,0 +1,31 @@
+# ===================================
+#  Form Behavior Config
+# ===================================
+
+# Record name
+name: ZipLookup
+
+# Model Form Field configuration
+form: $//lasso/ziplookup/models/ziplookup/fields.yaml
+
+# Model Class name
+modelClass: \Lasso\ZipLookup\Models\ZipLookup
+
+# Default redirect location
+defaultRedirect: /lasso/ziplookup/ziplookup
+
+# Create page
+create:
+    title: Create ZipLookup
+    redirect: /lasso/ziplookup/ziplookup/update/:id
+    redirectClose: /lasso/ziplookup/ziplookup
+
+# Update page
+update:
+    title: Edit ZipLookup
+    redirect: /lasso/ziplookup/ziplookup
+    redirectClose: /lasso/ziplookup/ziplookup
+
+# Preview page
+preview:
+    title: Preview ZipLookup

--- a/plugins/lasso/ziplookup/controllers/ziplookup/config_list.yaml
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/config_list.yaml
@@ -1,0 +1,44 @@
+# ===================================
+#  List Behavior Config
+# ===================================
+
+# Model List Column configuration
+list: $//lasso/ziplookup/models/ziplookup/columns.yaml
+
+# Model Class name
+modelClass: \Lasso\ZipLookup\Models\ZipLookup
+
+# List Title
+title: Manage ZipLookups
+
+# Link URL for each record
+recordUrl: /lasso/ziplookup/ziplookup/update/:id
+
+# Message to display if the list is empty
+noRecordsMessage: backend::lang.list.no_records
+
+# Records to display per page
+recordsPerPage: 20
+
+# Displays the list column set up button
+showSetup: true
+
+# Displays the sorting link on each column
+showSorting: true
+
+# Default sorting column
+# defaultSort:
+#     column: created_at
+#     direction: desc
+
+# Display checkboxes next to each record
+# showCheckboxes: true
+
+# Toolbar widget configuration
+toolbar:
+    # Partial for toolbar buttons
+    buttons: list_toolbar
+
+    # Search widget configuration
+    search:
+        prompt: backend::lang.list.search_prompt

--- a/plugins/lasso/ziplookup/controllers/ziplookup/create.htm
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/create.htm
@@ -1,0 +1,48 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>">ZipLookup</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class'=>'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="Creating ZipLookup..."
+                    class="btn btn-primary">
+                    Create
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="Creating ZipLookup..."
+                    class="btn btn-default">
+                    Create and Close
+                </button>
+                <span class="btn-text">
+                    or <a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>">Cancel</a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>" class="btn btn-default">Return to ziplookup list</a></p>
+
+<?php endif ?>

--- a/plugins/lasso/ziplookup/controllers/ziplookup/index.htm
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/index.htm
@@ -1,0 +1,2 @@
+
+<?= $this->listRender() ?>

--- a/plugins/lasso/ziplookup/controllers/ziplookup/preview.htm
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/preview.htm
@@ -1,0 +1,19 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>">ZipLookup</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <div class="form-preview">
+        <?= $this->formRenderPreview() ?>
+    </div>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>" class="btn btn-default">Return to ziplookup list</a></p>
+
+<?php endif ?>

--- a/plugins/lasso/ziplookup/controllers/ziplookup/update.htm
+++ b/plugins/lasso/ziplookup/controllers/ziplookup/update.htm
@@ -1,0 +1,56 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>">ZipLookup</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class'=>'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-request-data="redirect:0"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="Saving ZipLookup..."
+                    class="btn btn-primary">
+                    <u>S</u>ave
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="Saving ZipLookup..."
+                    class="btn btn-default">
+                    Save and Close
+                </button>
+                <button
+                    type="button"
+                    class="oc-icon-trash-o btn-icon danger pull-right"
+                    data-request="onDelete"
+                    data-load-indicator="Deleting ZipLookup..."
+                    data-request-confirm="Do you really want to delete this ziplookup?">
+                </button>
+                <span class="btn-text">
+                    or <a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>">Cancel</a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('/lasso/ziplookup/ziplookup') ?>" class="btn btn-default">Return to ziplookup list</a></p>
+
+<?php endif ?>

--- a/plugins/lasso/ziplookup/models/Rep.php
+++ b/plugins/lasso/ziplookup/models/Rep.php
@@ -1,0 +1,39 @@
+<?php namespace Lasso\ZipLookup\Models;
+
+use Model;
+
+/**
+ * Rep Model
+ */
+class Rep extends Model
+{
+
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'lasso_ziplookup_reps';
+
+    /**
+     * @var array Guarded fields
+     */
+    protected $guarded = ['*'];
+
+    /**
+     * @var array Fillable fields
+     */
+    protected $fillable = ['firstName','lastName','title','politicalParty','emailAddress','phoneNumber','physicalAddress','expireDate'];
+
+    protected $visible = ['id','firstName','lastName','title','politicalParty','emailAddress','phoneNumber','physicalAddress','expireDate'];
+    /**
+     * @var array Relations
+     */
+    public $hasOne = [];
+    public $hasMany = [];
+    public $belongsTo = [];
+    public $belongsToMany = [];
+    public $morphTo = [];
+    public $morphOne = [];
+    public $morphMany = [];
+    public $attachOne = [];
+    public $attachMany = [];
+}

--- a/plugins/lasso/ziplookup/models/ZipRecord.php
+++ b/plugins/lasso/ziplookup/models/ZipRecord.php
@@ -1,0 +1,37 @@
+<?php namespace Lasso\ZipLookup\Models;
+
+use Model;
+
+/**
+ * ZipRecord Model
+ */
+class ZipRecord extends Model
+{
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'lasso_ziplookup_zip_records';
+
+    /**
+     * @var array Guarded fields
+     */
+    protected $guarded = ['*'];
+
+    /**
+     * @var array Fillable fields
+     */
+    protected $fillable = ['representative_id', 'zip'];
+    protected $visible = ['representative_id', 'zip'];
+    /**
+     * @var array Relations
+     */
+    public $hasOne = [];
+    public $hasMany = [];
+    public $belongsTo = [];
+    public $belongsToMany = [];
+    public $morphTo = [];
+    public $morphOne = [];
+    public $morphMany = [];
+    public $attachOne = [];
+    public $attachMany = [];
+}

--- a/plugins/lasso/ziplookup/models/rep/columns.yaml
+++ b/plugins/lasso/ziplookup/models/rep/columns.yaml
@@ -1,0 +1,8 @@
+# ===================================
+#  List Column Definitions
+# ===================================
+
+columns:
+    id:
+        label: ID
+        searchable: true

--- a/plugins/lasso/ziplookup/models/rep/fields.yaml
+++ b/plugins/lasso/ziplookup/models/rep/fields.yaml
@@ -1,0 +1,8 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    id:
+        label: ID
+        disabled: true

--- a/plugins/lasso/ziplookup/models/ziprecord/columns.yaml
+++ b/plugins/lasso/ziplookup/models/ziprecord/columns.yaml
@@ -1,0 +1,14 @@
+# ===================================
+#  List Column Definitions
+# ===================================
+
+columns:
+        zip:
+         label: Zip
+         type: text
+         searchable: true
+
+        representative_id:
+         label: RepresentativeID
+         type: text
+         searchable: true

--- a/plugins/lasso/ziplookup/models/ziprecord/fields.yaml
+++ b/plugins/lasso/ziplookup/models/ziprecord/fields.yaml
@@ -1,0 +1,13 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    zip: Zip
+        label: Zip
+        description: Zip Code
+        type: text
+    representative_id: RepresentativeID
+        label: RepresentativeID
+        description: Representative ID
+        type: text

--- a/plugins/lasso/ziplookup/updates/create_reps_table.php
+++ b/plugins/lasso/ziplookup/updates/create_reps_table.php
@@ -1,0 +1,32 @@
+<?php namespace Lasso\ZipLookup\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class CreateRepsTable extends Migration
+{
+
+    public function up()
+    {
+        Schema::create('lasso_ziplookup_reps', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('firstName');
+            $table->string('lastName');
+            $table->string('title');
+            $table->string('politicalParty');
+            $table->string('emailAddress');
+            $table->string('phoneNumber');
+            $table->string('physicalAddress');
+            $table->date('expireDate');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('lasso_ziplookup_reps');
+    }
+
+}

--- a/plugins/lasso/ziplookup/updates/create_zip_records_table.php
+++ b/plugins/lasso/ziplookup/updates/create_zip_records_table.php
@@ -1,0 +1,30 @@
+<?php namespace Lasso\ZipLookup\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class CreateZipRecordsTable extends Migration
+{
+
+    public function up()
+    {
+        Schema::create('lasso_ziplookup_zip_records', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->unsignedInteger('representative_id');
+            $table->mediumInteger('zip');
+            $table->timestamps();
+            $table->primary(array('zip', 'representative_id'));
+            $table->foreign('representative_id')
+                ->references('id')
+                ->on('lasso_ziplookup_reps')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('lasso_ziplookup_zip_records');
+    }
+
+}

--- a/plugins/lasso/ziplookup/updates/version.yaml
+++ b/plugins/lasso/ziplookup/updates/version.yaml
@@ -1,0 +1,18 @@
+1.0.1: First version of ZipLookup
+1.0.2:
+   -   Added tables, views, controlers, models, migrations
+   -   create_reps_table.php
+   -   create_zip_records_table.php
+1.0.3:
+   -  Hopefully have correct columns.yaml and fields.yaml for ziprecord table
+1.0.4:
+  -   Added additional fields to enable effective cache checking
+1.0.5:
+  -   Added foriegn key to enable easy cascading deletes
+1.0.6:
+  -   Adjusted foriegn key entries
+1.0.7:
+  -   Better consistancy through better naming of fields
+  -   removed create_zips_table.php
+1.0.8:
+  -   Bugfix - missing title field in migration

--- a/themes/advocacy/pages/home.htm
+++ b/themes/advocacy/pages/home.htm
@@ -6,9 +6,14 @@ hidden = "0"
 [homeView]
 numberOfPosts = "4"
 postPage = "article"
+
+[homePage]
+petitionsOnHomePage = "5"
+noPetitionsMessage = "No petitions found"
 ==
 {% put styles %}
 <link rel="stylesheet" type="text/css" href="{{ 'assets/css/home.css'|theme }}">
 {% endput %}
 {% content 'whoweare.htm' %}
 {% component 'homeView' %}
+{% component 'homePage' %}

--- a/themes/advocacy/pages/p.htm
+++ b/themes/advocacy/pages/p.htm
@@ -1,5 +1,5 @@
 title = "Petition"
-url = "/petition/:slug"
+url = "/p/:slug"
 layout = "default"
 description = "The default layout of a petition obtainable using the petition's unique slug. For example www.example.com/petition/sample-petition"
 hidden = "0"

--- a/themes/advocacy/pages/petition.htm
+++ b/themes/advocacy/pages/petition.htm
@@ -1,6 +1,14 @@
 title = "Sign Petition"
-url = "/petition"
+url = "/petition/:pageNumber"
 layout = "default"
 hidden = "0"
+
+[frontEnd]
+showPublished = "true"
+pageNumber = "{{ :pageNumber }}"
+petitionsPerPage = "10"
+noPetitionsMessage = "No petitions found"
+petitionPage = "petition"
 ==
 {% content 'petition.htm' %}
+{% component 'frontEnd' %}


### PR DESCRIPTION
1.5.5:
- Fixed bug causing trivial changes, such as published or active, to
  trigger the immutability functions
- Added published functionality to petitions front end only published
  petitions will be viewable
- Added active functionality to petitions front end unactive petitions
  are still viewable but cannot be signed
- Added homePage component to home page in theme
- Added frontend component to Sign Petition page in theme
- Changed components class tags to match the theme and have the correct
  width.
- Fixed bug that was causing petitions signature count not to be reset
  when the immutability functions where triggered.
- Fixed css bug where alerts with type error had no styling, there was
  no css rule for .alert-error in the theme style.css, I added a rule to
  htis components css.
